### PR TITLE
Add support for 'XDG_STATE_HOME'

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ xdg.win32 = (options = {}) => {
   const appdata = env.XDG_CONFIG_HOME || APPDATA;
   const cache = resolve(XDG_CACHE_HOME || local, subdir, 'Cache');
   const config = resolve(appdata, subdir, 'Config');
-  const state = resolve(env.XDG_STATE_HOME || local, subdir, 'State');
+  const state = resolve(env.XDG_STATE_HOME || local);
 
   const dirs = {
     cache,

--- a/index.js
+++ b/index.js
@@ -53,11 +53,13 @@ xdg.darwin = (options = {}) => {
   const home = options.homedir || homedir('darwin');
   const data = resolve(env.XDG_DATA_HOME || app(), subdir);
   const config = resolve(env.XDG_CONFIG_HOME || app(), subdir);
+  const state = resolve(env.XDG_STATE_HOME || app(), subdir);
   const cch = resolve(env.XDG_CACHE_HOME || caches(), subdir);
   const etc = '/etc/xdg';
 
   const dirs = {
     cache: cch,
+    state,
     config,
     config_dirs: [config, ...split(env.XDG_CONFIG_DIRS || etc)],
     data,
@@ -93,16 +95,19 @@ xdg.linux = (options = {}) => {
   const cache = () => join(home, '.cache');
   const config = () => join(home, '.config');
   const share = () => join(home, '.local', 'share');
+  const state = () => join(home, '.local', 'state');
 
   const temp = options.tempdir || os.tmpdir();
   const home = options.homedir || homedir('linux');
   const data = resolve(env.XDG_DATA_HOME || share(), subdir);
+  const stte = resolve(env.XDG_STATE_HOME || state(), subdir);
   const cfg = resolve(env.XDG_CONFIG_HOME || config(), subdir);
   const cch = resolve(env.XDG_CACHE_HOME || cache(), subdir);
   const etc = '/etc/xdg';
 
   const dirs = {
     cache: cch,
+    state: stte,
     config: cfg,
     config_dirs: [cfg, ...split(env.XDG_CONFIG_DIRS || etc)],
     data,
@@ -155,9 +160,11 @@ xdg.win32 = (options = {}) => {
   const appdata = env.XDG_CONFIG_HOME || APPDATA;
   const cache = resolve(XDG_CACHE_HOME || local, subdir, 'Cache');
   const config = resolve(appdata, subdir, 'Config');
+  const state = resolve(env.XDG_STATE_HOME || local, subdir, 'State');
 
   const dirs = {
     cache,
+    state,
     config,
     config_dirs: [config, ...split(XDG_CONFIG_DIRS)],
     data,


### PR DESCRIPTION
As per #1, this adds `XDG_STATE_HOME` to directory resolution

I really wasn't sure what to do for Windows. [env-paths](https://github.com/sindresorhus/env-paths/blob/main/index.js#L21) uses `Logs` for this kind of stuff - have any suggestions?

<details>
<summary>Mocha Results</summary>

```sh
@(130) edwin ~/xdg (xdg-state-home ?) $ yarn run mocha
yarn run v1.22.10
$ /home/edwin/xdg/node_modules/.bin/mocha


  xdg-base-directory
{
  cache: '/home/edwin/.cache',
  state: '/home/edwin/state',
  config: '/home/edwin/config',
  config_dirs: [ '/home/edwin/config', '/etc/xdg' ],
  data: '/home/edwin/data',
  data_dirs: [ '/home/edwin/data', '/usr/local/share/', '/usr/share/' ],
  runtime: '/run/user/1000',
  logs: '/home/edwin/.cache/logs'
}
    ✓ should

  xdg-user-dirs
{
  cache: '/home/edwin/.cache',
  state: '/home/edwin/state',
  config: '/home/edwin/config',
  config_dirs: [ '/home/edwin/config', '/etc/xdg' ],
  data: '/home/edwin/data',
  data_dirs: [ '/home/edwin/data', '/usr/local/share/', '/usr/share/' ],
  runtime: '/run/user/1000',
  logs: '/home/edwin/.cache/logs'
}
    ✓ should


  2 passing (5ms)

Done in 0.19s.
```
![image](https://user-images.githubusercontent.com/24364012/130385393-ff97cadf-d25c-4f20-b3fe-25b7f4e87534.png)

</details>