### PR TITLE
Using process.platform as a proper default value.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const isWindows = process.platform === 'win32';
 const os = require('os');
 const path = require('path');
 const join = path.join;
@@ -16,7 +15,7 @@ const { homedir, load, resolve, split } = require('./lib/utils');
  */
 
 const xdg = (options = {}) => {
-  const platform = options.platform || (isWindows ? 'win32' : 'linux');
+  const platform = options.platform || process.platform;
   const fn = xdg[platform];
 
   if (typeof fn !== 'function') {

--- a/lib/userdirs.js
+++ b/lib/userdirs.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const isWindows = process.platform === 'win32';
 const path = require('path');
 const utils = require('./utils');
 const { homedir, load } = utils;
@@ -15,7 +14,7 @@ const { homedir, load } = utils;
  */
 
 const userdirs = (options = {}) => {
-  const platform = options.platform || (isWindows ? 'win32' : 'linux');
+  const platform = options.platform || process.platform;
   const fn = userdirs[platform];
 
   if (typeof fn !== 'function') {
@@ -251,7 +250,7 @@ userdirs.win32 = (options = {}) => {
  */
 
 userdirs.home = (options = {}) => {
-  const platform = options.platform || (isWindows ? 'win32' : 'linux');
+  const platform = options.platform || process.platform;
   return options.homedir || homedir(platform);
 };
 userdirs.load = load;


### PR DESCRIPTION
Documentation states that default value is 'process.platform'. This does not hold on Mac OS where the default value resolves to 'linux' and incorrect directories are returned for the default call. A workaround is to provide a platform in the options.

See #3 

Thank you for this awesome library.