### PR TITLE
Properly document parameters for linux variant

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ xdg.darwin = (options = {}) => {
  * ```js
  * const dirs = xdg.linux();
  * ```
- * @return {Object} Returns an object of paths.
+ * @param {Object} `options`
  * @return {Object} Returns an object of paths.
  * @api public
  */


### PR DESCRIPTION
Adds missing parameters to the Linux platform method.

There's no regenerated readme as I was unable to get `verb` to work